### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/albums-api/Controllers/UnsecuredController.cs
+++ b/albums-api/Controllers/UnsecuredController.cs
@@ -10,7 +10,23 @@ namespace UnsecureApp.Controllers
 
         public string ReadFile(string userInput)
         {
-            using (FileStream fs = File.Open(userInput, FileMode.Open))
+            // Validate user input
+            if (userInput.Contains("..") || userInput.Contains("/") || userInput.Contains("\\"))
+            {
+                throw new ArgumentException("Invalid file path");
+            }
+
+            // Restrict file access to a specific directory
+            string baseDirectory = "/safe/directory";
+            string filePath = Path.Combine(baseDirectory, userInput);
+            filePath = Path.GetFullPath(filePath);
+
+            if (!filePath.StartsWith(baseDirectory))
+            {
+                throw new UnauthorizedAccessException("Access to the path is denied");
+            }
+
+            using (FileStream fs = File.Open(filePath, FileMode.Open))
             {
                 byte[] b = new byte[1024];
                 UTF8Encoding temp = new UTF8Encoding(true);


### PR DESCRIPTION
Fixes [https://github.com/geovanams/GHASdemobra/security/code-scanning/1](https://github.com/geovanams/GHASdemobra/security/code-scanning/1)

To fix the problem, we need to validate the `userInput` before using it to construct a file path. We can ensure that the input does not contain any path separators or parent directory references. Additionally, we can restrict the file access to a specific directory to further mitigate the risk of path traversal attacks.

1. **Validation**: Check that `userInput` does not contain any ".." sequences or path separators ("/" or "\\").
2. **Restrict Directory**: Ensure that the file path is within a specific directory by combining the base directory with the validated `userInput` and checking the resolved path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
